### PR TITLE
Split controller and GRPC Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ ok      github.com/xtaci/kcp-go/v5      64.151s
 New added after [commit: Add fail route detect and switch backup route](https://github.com/colprog/kcp-go/commit/8b3bd52d2ed9c10f4cce254817196350b9761b46) and [commit: Test cases for new controller logic](https://github.com/colprog/kcp-go/commit/f46cafaec7f0907b2fdeb368e750099b5211f4df)
 
 Main logic:
-1. server and client side can call `NewControllerConfig` which stared a grpc control service
+1. server and client side can call `NewControllerServer` which stared a grpc control service
   - Used to register a grpc service 
   - Interface for grpc service
     - `GetSessions`(both work on server and client): get the snmp infomation from current sessions.

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -352,7 +352,7 @@ func startServer(args *BenchSerOps) error {
 		return err
 	}
 
-	slowListener.NewControllerConfig(nil, true)
+	slowListener.NewControllerServer(nil)
 
 	snmpTicker := startServerSnmpTricker(args)
 	defer snmpTicker.Stop()
@@ -395,13 +395,10 @@ func start(args *BenchCliOps) error {
 
 		cliConfig := kcp.NewDefaultConfig()
 		cliConfig.SetControllerPort(10721)
-		sess.SetSessionController(kcp.NewSessionController(cliConfig, false, true))
+		sess.SetSessionController(kcp.NewSessionController(cliConfig, false))
 
 		if args.monitor_interval != 0 {
-			err := sess.EnableMonitor(uint64(args.monitor_interval), args.detect_rate)
-			if err != nil {
-				return err
-			}
+			sess.EnableMonitor(uint64(args.monitor_interval), args.detect_rate)
 		}
 
 		for {

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -352,7 +352,7 @@ func startServer(args *BenchSerOps) error {
 		return err
 	}
 
-	slowListener.NewControllerConfig(nil)
+	slowListener.NewControllerConfig(nil, true)
 
 	snmpTicker := startServerSnmpTricker(args)
 	defer snmpTicker.Stop()
@@ -395,7 +395,7 @@ func start(args *BenchCliOps) error {
 
 		cliConfig := kcp.NewDefaultConfig()
 		cliConfig.SetControllerPort(10721)
-		sess.SetControllerServer(kcp.NewSessionControllerServer(cliConfig, false))
+		sess.SetSessionController(kcp.NewSessionController(cliConfig, false, true))
 
 		if args.monitor_interval != 0 {
 			err := sess.EnableMonitor(uint64(args.monitor_interval), args.detect_rate)

--- a/examples/echo.go
+++ b/examples/echo.go
@@ -18,7 +18,7 @@ func main() {
 
 	key := pbkdf2.Key([]byte("demo pass"), []byte("demo salt"), 1024, 32, sha1.New)
 	block, _ := kcp.NewAESBlockCrypt(key)
-	if listener, err := kcp.ListenWithOptions("127.0.0.1:12345", block, 10, 3, nil, kcp.DebugLevelLog); err == nil {
+	if listener, err := kcp.ListenWithDetailOptions("127.0.0.1:12345", block, 10, 3, nil, kcp.DebugLevelLog); err == nil {
 		// spin-up the client
 		go client()
 		for {
@@ -29,7 +29,7 @@ func main() {
 			go handleEcho(s)
 		}
 	} else {
-		kcp.LogFatalf("ListenWithOptions failed, error: %s", err)
+		kcp.LogFatalf("ListenWithDetailOptions failed, error: %s", err)
 	}
 }
 
@@ -59,7 +59,7 @@ func client() {
 	time.Sleep(time.Second)
 
 	// dial to the echo server
-	if sess, err := kcp.DialWithOptions("127.0.0.1:12345", block, 10, 3, nil, kcp.DebugLevelLog); err == nil {
+	if sess, err := kcp.DialWithDetailOptions("127.0.0.1:12345", block, 10, 3, nil, kcp.DebugLevelLog); err == nil {
 		for {
 			data := time.Now().String()
 			buf := make([]byte, len(data))
@@ -77,6 +77,6 @@ func client() {
 			time.Sleep(time.Second)
 		}
 	} else {
-		kcp.LogFatalf("DialWithOptions got error: %s", err)
+		kcp.LogFatalf("DialWithDetailOptions got error: %s", err)
 	}
 }

--- a/kcp.go
+++ b/kcp.go
@@ -926,7 +926,9 @@ func (kcp *KCP) flush(ackOnly bool) uint32 {
 			segment.una = seg.una
 
 			willPromote := segment.xmit > 3 || (segment.xmit >= 2 && len(kcp.acklist) > 0)
-			if willPromote || promoteToImportant {
+			// If globalSessionType is SessionTypeNormal
+			// Then current segment or ack won't be promote in `output`
+			if (willPromote || promoteToImportant) && globalSessionType != SessionTypeNormal {
 				segment.has_promote = true
 			}
 			flushACK(willPromote || promoteToImportant)

--- a/kcp.go
+++ b/kcp.go
@@ -566,7 +566,7 @@ func (kcp *KCP) parse_data(newseg segment) bool {
 // codecs.
 //
 // 'ackNoDelay' will trigger immediate ACK, but surely it will not be efficient in bandwidth
-func (kcp *KCP) Input(data []byte, regular, fromMetered, ackNoDelay bool, controller *ControllerServer) int {
+func (kcp *KCP) Input(data []byte, regular, fromMetered, ackNoDelay bool) int {
 	snd_una := kcp.snd_una
 
 	if len(data) < IKCP_OVERHEAD {

--- a/kcp_grpc_control.go
+++ b/kcp_grpc_control.go
@@ -439,14 +439,15 @@ func backupRouteWakeUp(sess *UDPSession, controller *SessionController) error {
 }
 
 func MonitorStart(sess *UDPSession, interval uint64, detectRate float64, controller *SessionController) {
-	// Monitor disabled
-	if globalSessionType == SessionTypeNormal {
-		return
-	}
+	// Allow SessionTypeNormal in dectection
 
 	sessMonitor := new(UDPSessionMonitor)
 
 	for {
+
+		// After MonitorStart, user may switch the session type by GRPC
+		// if globalSessionType == SessionTypeNormal
+		// Then just do nothing
 
 		changed := false
 		if globalSessionType == SessionTypeExistMetered {

--- a/listener.go
+++ b/listener.go
@@ -42,7 +42,7 @@ type (
 		dropKcpAckRate float64
 		dropOn         bool
 
-		contollerServer *ControllerServer
+		contollerServer *SessionController
 	}
 )
 
@@ -126,7 +126,7 @@ func (l *Listener) packetInput(data []byte, addr net.Addr) {
 				s := newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, false, addr, l.block)
 
 				if l.contollerServer != nil {
-					s.SetControllerServer(l.contollerServer)
+					s.SetSessionController(l.contollerServer)
 				}
 				s.kcpInput(data, isFromMeteredIP)
 				l.sessionLock.Lock()
@@ -152,11 +152,11 @@ func (l *Listener) notifyReadError(err error) {
 	})
 }
 
-func (l *Listener) NewControllerConfig(controllerConfig *ControllerServerConfig) (err error) {
+func (l *Listener) NewControllerConfig(controllerConfig *SessionControllerConfig, startGRPC bool) (err error) {
 	if len(l.sessions) != 0 || len(l.sessionAlias) != 0 {
 		return errors.New("already exist session, should create controller server before session in.")
 	}
-	l.contollerServer = NewSessionControllerServer(controllerConfig, true)
+	l.contollerServer = NewSessionController(controllerConfig, true, startGRPC)
 	return nil
 }
 

--- a/sess.go
+++ b/sess.go
@@ -53,14 +53,23 @@ var (
 )
 
 const (
+	SessionTypeOnlyMeteredMin int32 = SessionTypeNormal
+
 	SessionTypeNormal       int32 = 0
 	SessionTypeExistMetered int32 = 1
 	SessionTypeOnlyMetered  int32 = 2
+
+	SessionTypeOnlyMeteredMax int32 = SessionTypeOnlyMetered
 )
 
 var (
 	globalSessionType int32 = SessionTypeNormal
 )
+
+func RunningAsNormal() {
+	atomic.StoreInt32(&globalSessionType, SessionTypeNormal)
+	LogInfo("current session running as SessionTypeNormal")
+}
 
 func RunningAsExistMetered() {
 	atomic.StoreInt32(&globalSessionType, SessionTypeExistMetered)

--- a/sess_test.go
+++ b/sess_test.go
@@ -34,7 +34,7 @@ func dialEcho(port int) (*UDPSession, error) {
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
 	block, _ := NewSalsa20BlockCrypt(pass)
-	sess, err := DialWithOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
+	sess, err := DialWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +57,7 @@ func dialEcho(port int) (*UDPSession, error) {
 }
 
 func dialSink(port int) (*UDPSession, error) {
-	sess, err := DialWithOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 0, 0, nil, DebugLevelLog)
+	sess, err := DialWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 0, 0, nil, DebugLevelLog)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +80,7 @@ func dialTinyBufferEcho(port int) (*UDPSession, error) {
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
 	block, _ := NewSalsa20BlockCrypt(pass)
-	sess, err := DialWithOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
+	sess, err := DialWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +94,7 @@ func listenEcho(port int) (net.Listener, error) {
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
 	block, _ := NewSalsa20BlockCrypt(pass)
-	return ListenWithOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 0, nil, DebugLevelLog)
+	return ListenWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 0, nil, DebugLevelLog)
 }
 func listenTinyBufferEcho(port int) (net.Listener, error) {
 	//block, _ := NewNoneBlockCrypt(pass)
@@ -102,11 +102,11 @@ func listenTinyBufferEcho(port int) (net.Listener, error) {
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
 	block, _ := NewSalsa20BlockCrypt(pass)
-	return ListenWithOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
+	return ListenWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), block, 10, 3, nil, DebugLevelLog)
 }
 
 func listenSink(port int) (net.Listener, error) {
-	return ListenWithOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 0, 0, nil, DebugLevelLog)
+	return ListenWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 0, 0, nil, DebugLevelLog)
 }
 
 func echoServer(port int) net.Listener {
@@ -541,7 +541,7 @@ func TestSNMP(t *testing.T) {
 
 func TestListenerClose(t *testing.T) {
 	port := int(atomic.AddUint32(&baseport, 1))
-	l, err := ListenWithOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 10, 3, nil, DebugLevelLog)
+	l, err := ListenWithDetailOptions(fmt.Sprintf("127.0.0.1:%v", port), nil, 10, 3, nil, DebugLevelLog)
 	if err != nil {
 		t.Fail()
 	}
@@ -578,8 +578,8 @@ func newClosedFlagPacketConn(c net.PacketConn) *closedFlagPacketConn {
 // Listener should close a net.PacketConn that it created.
 // https://github.com/xtaci/kcp-go/issues/165
 func TestListenerOwnedPacketConn(t *testing.T) {
-	// ListenWithOptions creates its own net.PacketConn.
-	l, err := ListenWithOptions("127.0.0.1:0", nil, 0, 0, nil, DebugLevelLog)
+	// ListenWithDetailOptions creates its own net.PacketConn.
+	l, err := ListenWithDetailOptions("127.0.0.1:0", nil, 0, 0, nil, DebugLevelLog)
 	if err != nil {
 		panic(err)
 	}
@@ -642,7 +642,7 @@ func TestUDPSessionOwnedPacketConn(t *testing.T) {
 	defer l.Close()
 
 	// DialWithOptions creates its own net.PacketConn.
-	client, err := DialWithOptions(l.Addr().String(), nil, 0, 0, nil, DebugLevelLog)
+	client, err := DialWithDetailOptions(l.Addr().String(), nil, 0, 0, nil, DebugLevelLog)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- KCP-VPN already have GRPC interface
- After split controller logicial from GRPC, KCP-VPN can add controller logical into the its GRPC services.

also 
- Deal globalSessionType == SessionTypeNormal 
   - any package won't promote 
   - SessionTypeNormal can't be changed, after use reset the globalSessionType by RPC