### PR TITLE
Refactor meter route and support retry package(default not enable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# vs-code
+**/.vscode
+# OSX
+**/.DS_Store 
+Thumbs.db

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -446,6 +447,7 @@ func handleMessage(conn *kcp.UDPSession, args *BenchSerOps) {
 			if verifyFixData(buf, n, DefaultVerifyDataLength) {
 				verified = 1
 			} else {
+				kcp.LogWarn(hex.Dump(buf[0:DefaultVerifyDataLength]))
 				verified = 0
 			}
 		}

--- a/kcp.go
+++ b/kcp.go
@@ -887,7 +887,12 @@ func (kcp *KCP) flush(ackOnly bool) uint32 {
 
 			if size != 0 {
 				for _, mtu_buffer := range bpi.Used[i] {
-					kcp.output(mtu_buffer, len(mtu_buffer), true, uint32(i))
+					if i == bpi.Level {
+						kcp.output(mtu_buffer, len(mtu_buffer), true, 0)
+					} else {
+						kcp.output(mtu_buffer, len(mtu_buffer), true, uint32(i))
+					}
+
 				}
 				bpi.Used[i] = nil
 			}

--- a/sess.go
+++ b/sess.go
@@ -658,7 +658,12 @@ func (s *UDPSession) output(buf []byte, important bool, retryTimes uint32) {
 
 		msg.Buffers = [][]byte{bts}
 		msg.Addr = s.remote
-		s.txqueue = append(s.txqueue, msg)
+
+		// TBD: spec ack and non-ack
+		// dSegmentACKed will mess up
+		for i := 0; uint32(i) < (retryTimes + 1); i++ {
+			s.txqueue = append(s.txqueue, msg)
+		}
 		atomic.AddUint64(&DefaultSnmp.BytesSentFromNoMeteredRaw, uint64(length))
 		if shouldAddToMeteredQ {
 			msg.Addr = s.meteredRemote

--- a/sess.go
+++ b/sess.go
@@ -659,8 +659,7 @@ func (s *UDPSession) output(buf []byte, important bool, retryTimes uint32) {
 		msg.Buffers = [][]byte{bts}
 		msg.Addr = s.remote
 
-		// TBD: spec ack and non-ack
-		// dSegmentACKed will mess up
+		// If ack here, retryTimes will always be 0
 		for i := 0; uint32(i) < (retryTimes + 1); i++ {
 			s.txqueue = append(s.txqueue, msg)
 		}

--- a/sess.go
+++ b/sess.go
@@ -626,6 +626,8 @@ func (s *UDPSession) SetWriteBuffer(bytes int) error {
 func (s *UDPSession) output(buf []byte, important bool, retryTimes uint32) {
 	var ecc [][]byte
 
+	// Temporarily skip the retry logic, and the receiving end also needs to be modified accordingly, as sticking packets can lead to poor parsing of the header
+	retryTimes = 0
 	// 1. FEC encoding
 	if s.fecEncoder != nil {
 		ecc = s.fecEncoder.encode(buf)


### PR DESCRIPTION
## 1. A wasted in `kcp.go`

The `makeSpace` flush the lastest buffer
```
makeSpace := func(space int, important bool, retryTimes uint32) bool {
	size := len(buffer) - len(ptr)
	if size+space > int(kcp.mtu) {
		kcp.output(buffer, size, important, retryTimes)
		ptr = buffer[kcp.reserved:]
		return false
	}
	return important
}
```
The segment send here:
```
for k := range ref {
	segment := &ref[k]
	needsend := false
	if segment.acked == 1 {
		continue
	}
	...

	if needsend {
		... 

		willPromote := segment.xmit > 3 || (segment.xmit >= 2 && len(kcp.acklist) > 0)

		// If globalSessionType is SessionTypeNormal
		// Then current segment or ack won't be promote in `output`
		if (willPromote || promoteToImportant) && globalSessionType != SessionTypeNormal {
			segment.has_promote = true
		}

		flushACK(willPromote || promoteToImportant)

		need := IKCP_OVERHEAD + len(segment.data)
		promoteToImportant = makeSpace(need, promoteToImportant, segment.xmit) || willPromote
		ptr = segment.encode(ptr)
		copy(ptr, segment.data)
		ptr = ptr[len(segment.data):]

		if segment.xmit >= kcp.dead_link {
			kcp.state = 0xFFFFFFFF
		}
	}

	... 
}
```
Wasted case: If our package size is near `(kcp.mtu / 2) ~ N` 

1. loop 1: `important` is false
   - the return value `promoteToImportant` is true, because `buffer_size < kcp.mtu`
   - no package flushed
2. loop 2: `important` is true due to some strategies
   -  flushed
      - the return value `promoteToImportant` is false
      - the package in loop 1 will be flushed as `important`
   - no flushed
      - next buffer if can included will be flushed as `important`


## 2. Buffer pool to distinguish different level buffer
- Don't need call `flushACK` frequently
- Used to combine buffer before flush
- In the last, combined buffer cutter by MTU, and has priority, and more retransmission strategies.


