### PR TITLE
Add a enable-verify-mode flag into benchmark

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -439,7 +439,7 @@ func handleMessage(conn *kcp.UDPSession, maxSize int, verifyMode bool) {
 			}
 		case 0:
 			{
-				kcp.LogWarn("Server side revc: %d, verified failed")
+				kcp.LogWarn("Server side revc: %d, verified failed", n)
 				break
 			}
 		case 1:


### PR DESCRIPTION
`--enable-verify-mode` to verify recv data.