### PR TITLE
Optimize some details in kcp-go implementation

### DIFF
--- a/kcp.go
+++ b/kcp.go
@@ -874,8 +874,9 @@ func (bp *KCPBufferPool) CombineACKIfAllow() {
 
 	if ack_flat_size != 0 && level_0_flat_size != 0 &&
 		bp.mtu-level_0_buffer_off > ack_buffer_len {
+
 		ack_buffer := bp.Used[C32T64(bp.Level, ack_flat_size-1)]
-		level_0_buffer := bp.Used[C32T64(0, ack_flat_size-1)]
+		level_0_buffer := bp.Used[C32T64(0, level_0_flat_size-1)]
 
 		bp.UsedIndex[C32T64(0, level_0_flat_size-1)] += uint32(copy((*level_0_buffer)[level_0_buffer_off:], (*ack_buffer)[bp.Reserved:ack_buffer_len]))
 

--- a/kcp_test.go
+++ b/kcp_test.go
@@ -153,7 +153,7 @@ func createSegement(sn uint32, data []byte, len int) *segment {
 	return seg
 }
 
-func verifySeg(t *testing.T, data []byte, expectSN uint32, expectConv uint32, expectByte byte) {
+func verifySeg(t *testing.T, data []byte, data_len uint32, expectSN uint32, expectConv uint32, expectByte byte) {
 
 	conv := binary.LittleEndian.Uint32(data)
 	sn := binary.LittleEndian.Uint32(data[IKCP_SN_OFFSET:])
@@ -161,7 +161,7 @@ func verifySeg(t *testing.T, data []byte, expectSN uint32, expectConv uint32, ex
 	assert.Equal(t, expectConv, conv)
 	assert.Equal(t, expectSN, sn)
 
-	if len(data) != IKCP_OVERHEAD {
+	if data_len != IKCP_OVERHEAD {
 		verifyData := data[IKCP_OVERHEAD+10]
 		assert.Equal(t, expectByte, verifyData)
 	}
@@ -173,53 +173,53 @@ func TestBufferPool(t *testing.T) {
 	var expectConv uint32 = 123
 	var expectByte byte = 0x6
 
-	bp := NewKCPBufferPool(3, 0)
-	assert.Equal(t, 0, bp.GetBufferSize(0))
-	assert.Equal(t, 0, bp.GetBufferSize(1))
-	assert.Equal(t, 0, bp.GetBufferSize(2))
-	assert.Equal(t, 0, bp.getBufferSize(3, true)) // ack
-	assert.Equal(t, 0, bp.GetAckBufferSize())     // ack
+	bp := NewKCPBufferPool(3, 0, mtu)
+	assert.Equal(t, uint32(0), bp.GetBufferSize(0))
+	assert.Equal(t, uint32(0), bp.GetBufferSize(1))
+	assert.Equal(t, uint32(0), bp.GetBufferSize(2))
+	assert.Equal(t, uint32(0), bp.getBufferSize(3, true)) // ack
+	assert.Equal(t, uint32(0), bp.GetAckBufferSize())     // ack
 
 	ack_seg := createSegement(1, []byte{}, 0)
-	bp.EncodeAckSegInfo(ack_seg, mtu)
+	bp.EncodeAckSegInfo(ack_seg)
 
-	assert.Equal(t, 1, bp.GetAckBufferSize()) // ack
-	assert.Equal(t, IKCP_OVERHEAD, len(bp.Used[3][0]))
-	verifySeg(t, bp.Used[3][0], 1, expectConv, expectByte)
+	assert.Equal(t, uint32(1), bp.GetAckBufferSize()) // ack
+	assert.Equal(t, uint32(IKCP_OVERHEAD), bp.UsedIndex[C32T64(3, 0)])
+	verifySeg(t, *bp.Used[C32T64(3, 0)], IKCP_OVERHEAD, 1, expectConv, expectByte)
 
 	ack_seg = createSegement(2, []byte{}, 0)
-	bp.EncodeAckSegInfo(ack_seg, mtu)
-	assert.Equal(t, 1, bp.GetAckBufferSize())
-	assert.Equal(t, IKCP_OVERHEAD*2, len(bp.Used[3][0]))
-	verifySeg(t, bp.Used[3][0][IKCP_OVERHEAD:], 2, expectConv, expectByte)
+	bp.EncodeAckSegInfo(ack_seg)
+	assert.Equal(t, uint32(1), bp.GetAckBufferSize())
+	assert.Equal(t, uint32(IKCP_OVERHEAD*2), bp.UsedIndex[C32T64(3, 0)])
+	verifySeg(t, (*bp.Used[C32T64(3, 0)])[IKCP_OVERHEAD:], IKCP_OVERHEAD, 2, expectConv, expectByte)
 
 	buffer := make([]byte, 1000)
 	buffer[10] = expectByte
 	seg := createSegement(13, buffer, 1000)
-	bp.EncodeSegInfo(seg, mtu, 0)
-	assert.Equal(t, 1, len(bp.Used[0]))
-	assert.Equal(t, IKCP_OVERHEAD+1000, len(bp.Used[0][0]))
-	verifySeg(t, bp.Used[0][0], 13, expectConv, expectByte)
+	bp.EncodeSegInfo(seg, 0)
+	assert.Equal(t, uint32(1), bp.GetBufferSize(0))
+	assert.Equal(t, uint32(IKCP_OVERHEAD+1000), bp.UsedIndex[C32T64(0, 0)])
+	verifySeg(t, (*bp.Used[C32T64(0, 0)]), bp.UsedIndex[C32T64(0, 0)], 13, expectConv, expectByte)
 
 	seg = createSegement(14, buffer, 1000)
-	bp.EncodeSegInfo(seg, mtu, 0)
-	assert.Equal(t, 2, bp.GetBufferSize(0))
-	assert.Equal(t, IKCP_OVERHEAD+1000, len(bp.Used[0][1]))
-	verifySeg(t, bp.Used[0][1], 14, expectConv, expectByte)
+	bp.EncodeSegInfo(seg, 0)
+	assert.Equal(t, uint32(2), bp.GetBufferSize(0))
+	assert.Equal(t, uint32(IKCP_OVERHEAD+1000), bp.UsedIndex[C32T64(0, 1)])
+	verifySeg(t, (*bp.Used[C32T64(0, 1)]), bp.UsedIndex[C32T64(0, 1)], 14, expectConv, expectByte)
 
 	buffer = make([]byte, 500)
 	buffer[10] = expectByte
 	seg = createSegement(25, buffer, 500)
-	bp.EncodeSegInfo(seg, mtu, 1)
-	assert.Equal(t, 1, bp.GetBufferSize(1))
-	assert.Equal(t, IKCP_OVERHEAD+500, len(bp.Used[1][0]))
-	verifySeg(t, bp.Used[1][0], 25, expectConv, expectByte)
+	bp.EncodeSegInfo(seg, 1)
+	assert.Equal(t, uint32(1), bp.GetBufferSize(1))
+	assert.Equal(t, uint32(IKCP_OVERHEAD+500), bp.UsedIndex[C32T64(1, 0)])
+	verifySeg(t, (*bp.Used[C32T64(1, 0)]), bp.UsedIndex[C32T64(1, 0)], 25, expectConv, expectByte)
 
 	seg = createSegement(26, buffer, 500)
-	bp.EncodeSegInfo(seg, mtu, 1)
-	assert.Equal(t, 1, bp.GetBufferSize(1))
-	assert.Equal(t, IKCP_OVERHEAD*2+500*2, len(bp.Used[1][0]))
-	verifySeg(t, bp.Used[1][0][IKCP_OVERHEAD+500:], 26, expectConv, expectByte)
+	bp.EncodeSegInfo(seg, 1)
+	assert.Equal(t, uint32(1), bp.GetBufferSize(1))
+	assert.Equal(t, uint32(IKCP_OVERHEAD*2+500*2), bp.UsedIndex[C32T64(1, 0)])
+	verifySeg(t, (*bp.Used[C32T64(1, 0)])[IKCP_OVERHEAD+500:], IKCP_OVERHEAD+500, 26, expectConv, expectByte)
 }
 
 func TestBufferPoolMtuBound(t *testing.T) {
@@ -228,43 +228,45 @@ func TestBufferPoolMtuBound(t *testing.T) {
 	var expectConv uint32 = 123
 	var expectByte byte = 0x6
 
-	bp := NewKCPBufferPool(3, 0)
+	bp := NewKCPBufferPool(3, 0, ack_mtu)
 
 	var i uint32 = 1
 	for ; i <= 5; i++ {
 		ack_seg := createSegement(i, []byte{}, 0)
-		bp.EncodeAckSegInfo(ack_seg, ack_mtu)
-		assert.Equal(t, 1, bp.GetAckBufferSize())
-		assert.Equal(t, IKCP_OVERHEAD*i, uint32(len(bp.Used[3][0])))
-		verifySeg(t, bp.Used[3][0][IKCP_OVERHEAD*(i-1):], i, expectConv, expectByte)
+		bp.EncodeAckSegInfo(ack_seg)
+		assert.Equal(t, uint32(1), bp.GetAckBufferSize())
+		assert.Equal(t, uint32(IKCP_OVERHEAD*i), bp.UsedIndex[C32T64(3, 0)])
+		verifySeg(t, (*bp.Used[C32T64(3, 0)])[IKCP_OVERHEAD*(i-1):], IKCP_OVERHEAD, i, expectConv, expectByte)
 	}
 
 	ack_seg := createSegement(6, []byte{}, 0)
-	bp.EncodeAckSegInfo(ack_seg, ack_mtu)
-	assert.Equal(t, 2, bp.GetAckBufferSize())
-	assert.Equal(t, IKCP_OVERHEAD, len(bp.Used[3][1]))
-	verifySeg(t, bp.Used[3][1], 6, expectConv, expectByte)
+	bp.EncodeAckSegInfo(ack_seg)
+	assert.Equal(t, uint32(2), bp.GetAckBufferSize())
+	assert.Equal(t, uint32(IKCP_OVERHEAD), bp.UsedIndex[C32T64(3, 1)])
+	verifySeg(t, (*bp.Used[C32T64(3, 1)]), IKCP_OVERHEAD, 6, expectConv, expectByte)
+
+	bp = NewKCPBufferPool(3, 0, data_mtu)
 
 	i = 1
 	for ; i <= 3; i++ {
 		buffer := make([]byte, 500)
 		buffer[10] = expectByte
 		seg := createSegement(100+i, buffer, 500)
-		bp.EncodeSegInfo(seg, data_mtu, 1)
+		bp.EncodeSegInfo(seg, 1)
 
-		assert.Equal(t, 1, bp.GetBufferSize(1))
-		assert.Equal(t, (IKCP_OVERHEAD+500)*i, uint32(len(bp.Used[1][0])))
-		verifySeg(t, bp.Used[1][0][(IKCP_OVERHEAD+500)*(i-1):], 100+i, expectConv, expectByte)
+		assert.Equal(t, uint32(1), bp.GetBufferSize(1))
+		assert.Equal(t, uint32((IKCP_OVERHEAD+500)*i), bp.UsedIndex[C32T64(1, 0)])
+		verifySeg(t, (*bp.Used[C32T64(1, 0)])[(IKCP_OVERHEAD+500)*(i-1):], IKCP_OVERHEAD+500, 100+i, expectConv, expectByte)
 	}
 
 	buffer := make([]byte, 500)
 	buffer[10] = expectByte
 	seg := createSegement(1000, buffer, 500)
-	bp.EncodeSegInfo(seg, data_mtu, 1)
+	bp.EncodeSegInfo(seg, 1)
 
-	assert.Equal(t, 2, bp.GetBufferSize(1))
-	assert.Equal(t, (IKCP_OVERHEAD + 500), len(bp.Used[1][1]))
-	verifySeg(t, bp.Used[1][1], 1000, expectConv, expectByte)
+	assert.Equal(t, uint32(2), bp.GetBufferSize(1))
+	assert.Equal(t, uint32(IKCP_OVERHEAD+500), bp.UsedIndex[C32T64(1, 1)])
+	verifySeg(t, (*bp.Used[C32T64(1, 1)]), IKCP_OVERHEAD+500, 1000, expectConv, expectByte)
 }
 
 func TestBufferPoolWithReserved(t *testing.T) {
@@ -274,42 +276,44 @@ func TestBufferPoolWithReserved(t *testing.T) {
 	var expectConv uint32 = 123
 	var expectByte byte = 0x6
 
-	bp := NewKCPBufferPool(3, int(reserved))
+	bp := NewKCPBufferPool(3, int(reserved), ack_mtu)
 
 	var i uint32 = 1
 	for ; i <= 5; i++ {
 		ack_seg := createSegement(i, []byte{}, 0)
-		bp.EncodeAckSegInfo(ack_seg, ack_mtu)
-		assert.Equal(t, 1, bp.GetAckBufferSize())
-		assert.Equal(t, IKCP_OVERHEAD*i+reserved, uint32(len(bp.Used[3][0])))
-		verifySeg(t, bp.Used[3][0][IKCP_OVERHEAD*(i-1)+reserved:], i, expectConv, expectByte)
+		bp.EncodeAckSegInfo(ack_seg)
+		assert.Equal(t, uint32(1), bp.GetAckBufferSize())
+		assert.Equal(t, uint32(IKCP_OVERHEAD*i+reserved), bp.UsedIndex[C32T64(3, 0)])
+		verifySeg(t, (*bp.Used[C32T64(3, 0)])[IKCP_OVERHEAD*(i-1)+reserved:], IKCP_OVERHEAD, i, expectConv, expectByte)
 	}
 
 	ack_seg := createSegement(6, []byte{}, 0)
-	bp.EncodeAckSegInfo(ack_seg, ack_mtu)
-	assert.Equal(t, 2, bp.GetAckBufferSize())
-	assert.Equal(t, IKCP_OVERHEAD+reserved, uint32(len(bp.Used[3][1])))
-	verifySeg(t, bp.Used[3][1][reserved:], 6, expectConv, expectByte)
+	bp.EncodeAckSegInfo(ack_seg)
+	assert.Equal(t, uint32(2), bp.GetAckBufferSize())
+	assert.Equal(t, uint32(IKCP_OVERHEAD+reserved), bp.UsedIndex[C32T64(3, 1)])
+	verifySeg(t, (*bp.Used[C32T64(3, 1)])[reserved:], IKCP_OVERHEAD, 6, expectConv, expectByte)
+
+	bp = NewKCPBufferPool(3, int(reserved), data_mtu)
 
 	i = 1
 	for ; i <= 3; i++ {
 		buffer := make([]byte, 500)
 		buffer[10] = expectByte
 		seg := createSegement(100+i, buffer, 500)
-		bp.EncodeSegInfo(seg, data_mtu, 1)
+		bp.EncodeSegInfo(seg, 1)
 
-		assert.Equal(t, 1, bp.GetBufferSize(1))
-		assert.Equal(t, (IKCP_OVERHEAD+500)*i+reserved, uint32(len(bp.Used[1][0])))
-		verifySeg(t, bp.Used[1][0][(IKCP_OVERHEAD+500)*(i-1)+reserved:], 100+i, expectConv, expectByte)
+		assert.Equal(t, uint32(1), bp.GetBufferSize(1))
+		assert.Equal(t, uint32((IKCP_OVERHEAD+500)*i+reserved), bp.UsedIndex[C32T64(1, 0)])
+		verifySeg(t, (*bp.Used[C32T64(1, 0)])[(IKCP_OVERHEAD+500)*(i-1)+reserved:], IKCP_OVERHEAD+500, 100+i, expectConv, expectByte)
 	}
 
 	buffer := make([]byte, 500)
 	buffer[10] = expectByte
 	seg := createSegement(1000, buffer, 500)
-	bp.EncodeSegInfo(seg, data_mtu, 1)
+	bp.EncodeSegInfo(seg, 1)
 
-	assert.Equal(t, 2, bp.GetBufferSize(1))
-	assert.Equal(t, (IKCP_OVERHEAD+500)+reserved, uint32(len(bp.Used[1][1])))
-	verifySeg(t, bp.Used[1][1][reserved:], 1000, expectConv, expectByte)
+	assert.Equal(t, uint32(2), bp.GetBufferSize(1))
+	assert.Equal(t, uint32((IKCP_OVERHEAD+500)+reserved), bp.UsedIndex[C32T64(1, 1)])
+	verifySeg(t, (*bp.Used[C32T64(1, 1)])[reserved:], IKCP_OVERHEAD+1000, 1000, expectConv, expectByte)
 
 }

--- a/sess.go
+++ b/sess.go
@@ -655,6 +655,11 @@ func (s *UDPSession) output(buf []byte, important bool, retryTimes uint32) {
 	shouldAddToMeteredQ := important && s.meteredRemote != nil
 	shouldAddToMeteredQ = SessionTypeDealImportPackage(shouldAddToMeteredQ, s.meteredRemote != nil)
 
+	// if current package added to meter, should not puts it into retry queue.
+	if shouldAddToMeteredQ {
+		retryTimes = 0
+	}
+
 	// 4. TxQueue
 	var msg ipv4.Message
 	for i := 0; i < s.dup+1; i++ {


### PR DESCRIPTION
- [x] reused buffer
- [x] reduce fullack call
- [x] combine ack buffer into other buffers
- [x] immediately flush buffer if  cwnd is full
- [x] remove (if segment.sn == 0)
- [x] promoted package should not dump send
- [x] cpu pprof/perf 